### PR TITLE
maxAge option, 1 day expire default

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -12,7 +12,8 @@ module.exports = function(options) {
   var uglify = require("uglify-js"),
       fsys = require("../lib/filesystem.js"),
       url = require("url"),
-      src;
+      src,
+      maxAge = options.maxAge || 86400000; // default to 1 day
 
   if(options.hasOwnProperty("src")) {
     src = options.src;
@@ -57,6 +58,8 @@ module.exports = function(options) {
 
             } else {
               console.log('"GET', path, '" 200 - Cached');
+              res.setHeader('Expires', new Date(Date.now() + maxAge).toUTCString());
+              res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
               res.contentType("js");
               res.send(data, 200);
             }


### PR DESCRIPTION
Adds the maxAge option for expiry headers, defaulting to 1 day

app.use(uglify.middleware({ src: __dirname + '/public', maxAge: 604800000 }));
