### PR TITLE
Use "uglify-js": "~1" to fetch >= 1.0.0 and <2.0.0 (which is incompatible)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">=0.6.x"
   },
   "dependencies": {
-    "uglify-js": ">=1.0.2",
+    "uglify-js": "~1",
     "winston": "0.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
It's explained here https://github.com/mishoo/UglifyJS#install-npm

Which gives us:

error: /javascripts/jquery-1.8.3.js TypeError: Cannot call method 'parse' of undefined
warning: "GET /javascripts/jquery-1.8.3.js" 200 - Failed to Minify
GET /javascripts/jquery-1.8.3.js 200 23ms - 259.82kb

Instead of:

info: "GET /javascripts/jquery-1.8.3.js" 200 - Minified
GET /javascripts/jquery-1.8.3.js 200 3599ms - 91.38kb
debug: Cached uglified: /javascripts/jquery-1.8.3.js
