### PR TITLE
Unhardcode UglifyJs's options.strict_semicolons

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -47,7 +47,7 @@ module.exports = function(options) {
             if(!isCached) {
               var ast;
               try {
-                ast = uglify.parser.parse(data, true);
+                ast = uglify.parser.parse(data, options.strict_semicolons);
                 ast = uglify.uglify.ast_mangle(ast);
                 ast = uglify.uglify.ast_squeeze(ast);
                 ast = uglify.uglify.gen_code(ast);


### PR DESCRIPTION
This allows for overriding Uglify's strict_semicolons option :

  app.use(require('express-uglify').middleware({
      src: __dirname + '/public',
      strict_semicolons: false
  }));
